### PR TITLE
Updated copyright details for MIT and Apache licenses

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
@@ -638,7 +638,7 @@ If the Library as you received it specifies that a proxy can decide whether futu
 	def generatePythonHlProjectLicenseMIT(PogoDeviceClass cls) '''
 	The MIT License
 
-Copyright (c) 2006-2010 Stephen M. McKamey
+Copyright (c) «IF cls.description.copyright.isSet»«cls.description.copyright.oneLineString»«ELSE»<YEAR> <COPYRIGHT HOLDER>«ENDIF»
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -887,7 +887,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright «IF cls.description.copyright.isSet»«cls.description.copyright.oneLineString»«ELSE»[yyyy] [name of copyright owner]«ENDIF»
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The class copyright written is taken as as copyright details inside description of MIT and Apache licenses.